### PR TITLE
Certs object property and getCookie method now act the same for both platforms

### DIFF
--- a/android/src/main/java/com/toyberman/RNSslPinningModule.java
+++ b/android/src/main/java/com/toyberman/RNSslPinningModule.java
@@ -113,8 +113,11 @@ public class RNSslPinningModule extends ReactContextBaseJavaModule {
             WritableMap map = new WritableNativeMap();
 
             List<Cookie> cookies = cookieStore.get(getDomainName(domain));
-            for (Cookie cookie : cookies) {
-                map.putString(cookie.name(), cookie.value());
+            
+            if (cookies != null) {
+                for (Cookie cookie : cookies) {
+                    map.putString(cookie.name(), cookie.value());
+                }
             }
 
             promise.resolve(map);

--- a/android/src/main/java/com/toyberman/RNSslPinningModule.java
+++ b/android/src/main/java/com/toyberman/RNSslPinningModule.java
@@ -3,6 +3,7 @@ package com.toyberman;
 import android.support.annotation.NonNull;
 
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -123,7 +124,7 @@ public class RNSslPinningModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void fetch(String hostname, ReadableMap options, Promise promise) {
+    public void fetch(String hostname, ReadableMap options, Callback callback) {
 
         WritableMap response = Arguments.createMap();
         // With ssl pinning
@@ -137,11 +138,11 @@ public class RNSslPinningModule extends ReactContextBaseJavaModule {
                     client = OkHttpUtils.buildOkHttpClient(cookieJar, hostname, certs, options);
                 }
             } else {
-                promise.reject(new Throwable("key certs was not found"));
+                callback.invoke(new Throwable("key certs was not found"), null);
             }
         } else {
             //no ssl pinning
-            promise.reject(new Throwable("sslPinning key was not added"));
+            callback.invoke(new Throwable("sslPinning key was not added"), null);
             return;
         }
 
@@ -160,12 +161,12 @@ public class RNSslPinningModule extends ReactContextBaseJavaModule {
                 response.putString("bodyString", stringResponse);
                 response.putMap("headers", headers);
 
-                promise.resolve(response);
+                callback.invoke(null, response);
             } else {
-                promise.reject(Integer.toString(okHttpResponse.code()), okHttpResponse.message());
+                callback.invoke(Integer.toString(okHttpResponse.code()), okHttpResponse.message(), null);
             }
         } catch (IOException | JSONException e) {
-            promise.reject(e);
+            callback.invoke(e, null);
         }
 
     }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var Q = require('q');
 
 module.exports = {
     getCookies : RNSslPinning.getCookies,
-    fetch: Platform.OS === 'android' ? RNSslPinning.fetch : function (url, obj, callback) {
+    fetch: function (url, obj, callback) {
         var deferred = Q.defer();
         RNSslPinning.fetch(url, obj, (err, res) => {
             if (err) {

--- a/ios/RNSslPinning.m
+++ b/ios/RNSslPinning.m
@@ -28,14 +28,14 @@ RCT_EXPORT_MODULE();
     return self;
 }
 
-RCT_REMAP_METHOD(getCookies, findEventsWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject){
+RCT_EXPORT_METHOD(getCookies: (NSURL *)url resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject){
     
     NSHTTPCookie *cookie;
     NSHTTPCookieStorage* cookieJar  =  NSHTTPCookieStorage.sharedHTTPCookieStorage;
     
     NSMutableDictionary* dictionary = @{}.mutableCopy;
     
-    for (cookie in [cookieJar cookies]) {
+    for (cookie in [cookieJar cookiesForURL:url]) {
         [dictionary setObject:cookie.value forKey:cookie.name];
     }
     
@@ -114,4 +114,3 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
 }
 
 @end
-

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "react-native"
   ],
   "author": "Max Toyberman",
+  "dependencies": {
+    "q": "^1.4.1"
+  },
   "license": "",
   "peerDependencies": {
     "react-native": "^0.41.2"


### PR DESCRIPTION
Hi! I fixed certain differences between Android and iOS implementations of this plugin.

1. Android expected sha256 encoded string version of certificate (and not filename, like stated in the Readme), thus the plugin didn't work since domain name was absent.
2. getCookies method now expects string for both platforms