### PR TITLE
Fixed authorization header would not work issue

### DIFF
--- a/android/src/main/java/com/toyberman/Utils/Utilities.java
+++ b/android/src/main/java/com/toyberman/Utils/Utilities.java
@@ -63,7 +63,7 @@ public class Utilities {
         ReadableMapKeySetIterator iterator = map.keySetIterator();
         while (iterator.hasNextKey()) {
             String key = iterator.nextKey();
-            builder.addHeader(key, map.getString(key).toLowerCase());
+            builder.addHeader(key, map.getString(key));
         }
     }
 


### PR DESCRIPTION
Since the authorization header will include values that contains some encrypted data probably contains both uppercase and lowercase letters, remove the toLowerCase to support it