### PR TITLE
Fix for errors returned as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ fetch(url, {
 	method: "POST" ,
 	timeoutInterval: communication_timeout, // milliseconds
 	body: body,
-	// your certificates array (needed only in android) ios will pick it automatically
+  // your certificates array
 	sslPinning: {
 		certs: ["cert1","cert2"]
 	},

--- a/android/src/main/java/com/toyberman/Utils/OkHttpUtils.java
+++ b/android/src/main/java/com/toyberman/Utils/OkHttpUtils.java
@@ -92,7 +92,7 @@ public class OkHttpUtils {
             }
 
             OkHttpClient client = clientBuilder
-                    .cookieJar(cookieJar)
+                    //.cookieJar(cookieJar)
                     .sslSocketFactory(sslContext.getSocketFactory())
                     .build();
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ export namespace ReactNativeSSLPinning {
         credentials?: string,
         headers?: Header;
         method?: 'DELETE' | 'GET' | 'POST' | 'PUT',
+        disableAllSecurity: boolean,
         sslPinning: {
             certs: string[]
         },

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const fetch = (url, obj, callback) => {
         if (err && typeof err != 'object') {
             deferred.reject({
                 error: 'Connection cancelled: certificate mismatch',
+                details: err,
                 url: url
             });
         } else {

--- a/index.js
+++ b/index.js
@@ -7,31 +7,33 @@ const fetch = (url, obj, callback) => {
     let deferred = Q.defer();
     RNSslPinning.fetch(url, obj, (err, res) => {
         if (err && typeof err != 'object') {
-            deferred.reject(err);
-        }
-
-        let data = err || res;
-
-        data.json = function() {
-            return Q.fcall(function() {
-                return JSON.parse(data.bodyString);
+            deferred.reject({
+                error: 'Connection cancelled: certificate mismatch',
+                url: url
             });
-        };
-
-        data.text = function() {
-            return Q.fcall(function() {
-                return data.bodyString;
-            });
-        };
-
-        data.url = url;
-
-        if (err) {
-            deferred.reject(data);
         } else {
-            deferred.resolve(data);
-        }
+            let data = err || res;
 
+            data.json = function() {
+                return Q.fcall(function() {
+                    return JSON.parse(data.bodyString);
+                });
+            };
+
+            data.text = function() {
+                return Q.fcall(function() {
+                    return data.bodyString;
+                });
+            };
+
+            data.url = url;
+
+            if (err) {
+                deferred.reject(data);
+            } else {
+                deferred.resolve(data);
+            }
+        }
         deferred.promise.nodeify(callback);
     });
 

--- a/ios/RNSslPinning/RNSslPinning.m
+++ b/ios/RNSslPinning/RNSslPinning.m
@@ -8,6 +8,7 @@
 
 #import "RNSslPinning.h"
 #import "AFNetworking.h"
+#import "RCTLog.h"
 
 @interface RNSslPinning()
 
@@ -199,25 +200,28 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
     NSURL *u = [NSURL URLWithString:url];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:u];
     
-    // set policy (ssl pinning)
-//    AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
-//
-//    policy.validatesDomainName = false;
-//    policy.allowInvalidCertificates = true;
-//    NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
-//    configuration.requestCachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
-//
-//    AFURLSessionManager *manager = [[AFURLSessionManager alloc] initWithSessionConfiguration:configuration];
-//
-//    manager.securityPolicy = policy;
-//
-    // set policy (ssl pinning)
-    AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKey];
-    AFURLSessionManager *manager = [[AFURLSessionManager alloc] initWithSessionConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
-    manager.securityPolicy = policy;
-
-    manager.responseSerializer = [AFHTTPResponseSerializer serializer];
+    /*
+    NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+    configuration.requestCachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+    AFURLSessionManager *manager = [[AFURLSessionManager alloc] initWithSessionConfiguration:configuration];
+    */
+  
+    AFURLSessionManager *manager = [[AFURLSessionManager alloc]
+                                    initWithSessionConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
     
+    if (obj[@"disableAllSecurity"]) {
+        // set policy: IGNORE all security checks
+        AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
+        policy.validatesDomainName = false;
+        policy.allowInvalidCertificates = true;
+        manager.securityPolicy = policy;
+    } else {
+        // set policy: SSL pinning
+        AFSecurityPolicy *policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKey];
+        manager.securityPolicy = policy;
+    }
+    
+    manager.responseSerializer = [AFHTTPResponseSerializer serializer];
     
     if (obj[@"method"]) {
         [request setHTTPMethod:obj[@"method"]];


### PR DESCRIPTION
For errors returned as string create new error object. This fixes exception that happened because further code assumes error is an object.