### PR TITLE
Add the pkPinning property to the Options object for TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ export namespace ReactNativeSSLPinning {
         credentials?: string,
         headers?: Header;
         method?: 'DELETE' | 'GET' | 'POST' | 'PUT',
+        pkPinning?: boolean,
         sslPinning: {
             certs: string[]
         },


### PR DESCRIPTION
Solution for issue [69](https://github.com/MaxToyberman/react-native-ssl-pinning/issues/69).