### PR TITLE
FIX: Prevent assignment on error string

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,19 +18,21 @@ const fetch = (url, obj, callback) => {
 
         let data = err || res;
 
-        data.json = function() {
-            return Q.fcall(function() {
-                return JSON.parse(data.bodyString);
-            });
-        };
+        if (typeof data === 'object') {
+            data.json = function() {
+                return Q.fcall(function() {
+                    return JSON.parse(data.bodyString);
+                });
+            };
 
-        data.text = function() {
-            return Q.fcall(function() {
-                return data.bodyString;
-            });
-        };
+            data.text = function() {
+                return Q.fcall(function() {
+                    return data.bodyString;
+                });
+            };
 
-        data.url = url;
+            data.url = url;
+        }
 
         if (err) {
             deferred.reject(data);


### PR DESCRIPTION
When native modules return error of type 'string', we need to avoid
attempting to assign properties to it to avoid an unhandled exception

I encountered this issue when handling a timeout concern, as both the iOS and Android native modules were returning some form of string message and ultimately throwing unhandled exceptions due the `data.json` assignment

iOS
<img width="200" alt="Screen Shot 2020-06-08 at 12 15 32 PM" src="https://user-images.githubusercontent.com/42143955/84054935-216f3400-a982-11ea-93cb-e86777b1af70.png">

android
<img width="200" alt="Screen Shot 2020-06-08 at 12 16 19 PM" src="https://user-images.githubusercontent.com/42143955/84054960-27651500-a982-11ea-931a-6f4a658add61.png">

I went with the least obstructive change, as this only avoids any erroneous assignment but does not otherwise affect response types or expected behavior. It seemed straightforward enough to just cut a PR, but let me know if this need to start from /issues first.