### PR TITLE
allow headers to be case sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,20 @@ fetch("https://publicobject.com", {
         Accept: "application/json; charset=utf-8", "Access-Control-Allow-Origin": "*", "e_platform": "mobile",
       }
 	})
+		
+```
+### Case Sensitive Headers
+```javascript
+
+ fetch("https://publicobject.com", {
+      method: "GET" ,
+      timeoutInterval: 10000, // milliseconds
+	  caseSensitiveHeaders: true, //in case you want headers to be case Sensitive
+      headers: {
+		Accept: "application/json; charset=utf-8", "Access-Control-Allow-Origin": "*", "e_platform": "mobile",
+		SOAPAction: "testAction",
+      }
+	})
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ fetch("https://publicobject.com", {
  fetch("https://publicobject.com", {
       method: "GET" ,
       timeoutInterval: 10000, // milliseconds
-	  caseSensitiveHeaders: true, //in case you want headers to be case Sensitive
+      caseSensitiveHeaders: true, //in case you want headers to be case Sensitive
       headers: {
 		Accept: "application/json; charset=utf-8", "Access-Control-Allow-Origin": "*", "e_platform": "mobile",
 		SOAPAction: "testAction",

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,8 @@ export namespace ReactNativeSSLPinning {
             certs: string[]
         },
         timeoutInterval?: number,
-        disableAllSecurity?: boolean
+        disableAllSecurity?: boolean,
+        caseSensitiveHeaders?: boolean = false
     }
 
     interface Response {

--- a/index.js
+++ b/index.js
@@ -6,10 +6,14 @@ const { RNSslPinning } = NativeModules;
 const fetch = (url, obj, callback) => {
     let deferred = Q.defer();
 
-    if(obj.headers){
+    if (obj.headers) {
         obj.headers = Object.keys(obj.headers)
-              .reduce((acc, key) => ({ ...acc,[key.toLowerCase()] : obj.headers[key]}), {})
+            .reduce((acc, key) => ({
+                ...acc,
+                [obj.caseSensitiveHeaders ? key : key.toLowerCase()]: obj.headers[key]
+            }), {})
     }
+
 
     RNSslPinning.fetch(url, obj, (err, res) => {
         if (err && typeof err != 'object') {


### PR DESCRIPTION
First of all, I really want to thank you for this awesome package. I was really fighting with SSL pinning in react native and found this package which helped me a lot. Unfortunately, I’m dealing with a service that’s somewhat particular about receiving `SOAPAction` instead of `soapaction`. (strictly case sensitive header). I was getting `400 Bad Request` due to the case sensitive problem and came across this optional case sensitivity solution. So if someone really wishes to have case sensitive headers could pass `caseSensitiveHeaders` as `true` and then will have the header values same as passed. Which means `SOAPAction` in my case.

I think this will add a bit more flexibility to this awesome package.

Thanks in advance,
Anupam Goyal