### PR TITLE
ISSUE-137    Typescript: update Options and Response interfaces to support base64 as a response type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ export namespace ReactNativeSSLPinning {
 
     interface Options {
         body?: string | object,
+        responseType?: 'text' | 'base64',
         credentials?: string,
         headers?: Header;
         method?: 'DELETE' | 'GET' | 'POST' | 'PUT',
@@ -22,7 +23,8 @@ export namespace ReactNativeSSLPinning {
     }
 
     interface Response {
-        bodyString: string;
+        bodyString?: string;
+        data?: string;
         headers: Header;
         status: number;
         url: string;


### PR DESCRIPTION
Hello @MaxToyberman ,

I have noticed Android and iOS scripts allow us to use parameter `responseType` so next to the `text`/`json` response we can get a `base64` response as well. However if we use TypeScript we are limited by interface `Options` where the `responseType` option is missing. Would you consider merging this into your code so even TypeScript devs will be able to get `base64` response?

With this change, if we add parameter `responseType` with `base64` value into `options`, we can get a `base64` response.

Thanks in advance,

Martin