### PR TITLE
npm v7 - updated rn peer dependency (any version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "homepage": "https://github.com/MaxToyberman/react-native-ssl-pinning#README",
   "peerDependencies": {
-    "react-native": "^0.41.2"
+    "react-native": "*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
PR for issue https://github.com/MaxToyberman/react-native-ssl-pinning/issues/153