### PR TITLE
added an option to pass body as an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,10 @@ const fetch = (url, obj, callback) => {
                 [obj.caseSensitiveHeaders ? key : key.toLowerCase()]: obj.headers[key]
             }), {})
     }
-
+    
+    if (obj.body && typeof obj.body === "object") {
+      obj.body = JSON.stringify(body);
+    }
 
     RNSslPinning.fetch(url, obj, (err, res) => {
         if (err && typeof err != 'object') {


### PR DESCRIPTION
Added a condition for body stringification in case passed as object,
this is also fixing the type matching: `body?: string | object,`