### PR TITLE
android timeout fix

### DIFF
--- a/android/src/main/java/com/toyberman/Utils/OkHttpUtils.java
+++ b/android/src/main/java/com/toyberman/Utils/OkHttpUtils.java
@@ -88,21 +88,20 @@ public class OkHttpUtils {
 
 
             clientsByDomain.put(domainName, client);
-            return client;
+        } else {
+            client = clientsByDomain.get(domainName);
         }
 
-        client = clientsByDomain.get(domainName);
 
 
         if (options.hasKey("timeoutInterval")) {
             int timeout = options.getInt("timeoutInterval");
             // Copy to customize OkHttp for this request.
-            OkHttpClient client2 = client.newBuilder()
+            client = client.newBuilder()
                     .readTimeout(timeout, TimeUnit.MILLISECONDS)
                     .writeTimeout(timeout, TimeUnit.MILLISECONDS)
                     .connectTimeout(timeout, TimeUnit.MILLISECONDS)
                     .build();
-            return client2;
         }
 
 


### PR DESCRIPTION
fix for: 

"clientsByDomain" logic was returning httpClient before "timeoutInterval" if condition could modify it.

possible fix for: https://github.com/MaxToyberman/react-native-ssl-pinning/issues/57