### PR TITLE
Update build.gradle for RN 0.72 compat

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     buildToolsVersion "28.0.3"
 
     defaultConfig {


### PR DESCRIPTION
Project fails to build with React Native 0.72+ because of minimum Android API target requirement

This is the minimal fix for #190

A more thorough upgrade is desirable at some time but please get this merged as we depend on automated build processes which currently are broken for RN 0.72 😢 