### PR TITLE
Check if it's a web url or a local file url before create a NSURL

### DIFF
--- a/ios/RNSslPinning/RNSslPinning.m
+++ b/ios/RNSslPinning/RNSslPinning.m
@@ -138,8 +138,14 @@ RCT_EXPORT_METHOD(removeCookieByName: (NSString *)cookieName
     NSString * fileName = [value objectForKey:@"name"] ? [value objectForKey:@"name"] : [value objectForKey:@"fileName"];
     NSString * mimeType = [value objectForKey:@"type"];
     NSString * path = [value objectForKey:@"uri"] ? [value objectForKey:@"uri"] : [value objectForKey:@"path"];
-    
-    [formData appendPartWithFileURL:[NSURL URLWithString:path] name:key fileName:fileName mimeType:mimeType error:nil];
+    NSURL * url = nil;
+    if ([path hasPrefix:@"http://"] || [path hasPrefix:@"https://"]) {
+        url = [NSURL URLWithString:path];
+    } else {
+        url = [NSURL fileURLWithPath:path];
+    }
+
+    [formData appendPartWithFileURL:url name:key fileName:fileName mimeType:mimeType error:nil];
 }
 
 -(void) performMultipartRequest: (AFURLSessionManager*)manager obj:(NSDictionary *)obj url:(NSString *)url request:(NSMutableURLRequest*) request callback:(RCTResponseSenderBlock) callback formData:(NSDictionary*) formData {


### PR DESCRIPTION
Refer to https://github.com/MaxToyberman/react-native-ssl-pinning/issues/120

I think there are 2 use cases for a user to submit a form-data:
1. submit from web url
2. submit from a local file in the user's phone

Then I think we could add this code to handle both cases 